### PR TITLE
Update README.md: add MwmStatistics skip.

### DIFF
--- a/maps_generator/README.md
+++ b/maps_generator/README.md
@@ -77,7 +77,7 @@ SUBWAY_URL: http://osm-subway.maps.me/mapsme/latest.json
 
 2. Run docker cantainer:
 ```sh
-Projects$ docker run -v ~/Projects/generation:/mapsme/generation: --rm -t maps_generator --config=/mapsme/generation/config.ini --countries="Uzbekistan" --skip="Coastline"
+Projects$ docker run -v ~/Projects/generation:/mapsme/generation: --rm -t maps_generator --config=/mapsme/generation/config.ini --countries="Uzbekistan" --skip="Coastline,MwmStatistics"
 ```
 
 3. Check maps:


### PR DESCRIPTION
Текущий readme не работал, т.к. stage MwmStatistics требовал указания пути к конфигу, после указания пути к конфигу у пользователя вылезли проблемы с юникод и т.п.

Соответсвенно есть 2 пути исправления инструкции:
* либо добавить в образец конфига генерации пути к конфигам типов для статистики и описывать как в докере всё настроить чтобы при парсинге конфига проблем не было
* либо пропускать MwmStatistics.

Т.к. MwmStatistics никому кроме нас не нужна и на данные не влияет, я думаю лучше пропускать MwmStatistics, чем заставлять пользователя делать ненужную ему работу.

https://github.com/mapsme/dockerfiles/issues/3